### PR TITLE
Implement generic JPA-style repository utilities

### DIFF
--- a/Java_intervew/src/Annotation/Column.java
+++ b/Java_intervew/src/Annotation/Column.java
@@ -1,4 +1,28 @@
 package Annotation;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares how a field should be mapped to a database column.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
 public @interface Column {
+    /**
+     * Optional explicit column name. When left empty the field name is used.
+     */
+    String name() default "";
+
+    /**
+     * Whether the column allows null values.
+     */
+    boolean nullable() default true;
+
+    /**
+     * Optional length hint for text based columns.
+     */
+    int length() default 255;
 }

--- a/Java_intervew/src/Annotation/Entity.java
+++ b/Java_intervew/src/Annotation/Entity.java
@@ -6,10 +6,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Declares the table name that backs an entity.
+ * Marks a class as a persistable entity that can be handled by the pseudo JPA layer.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface Table {
-    String name() default "";
+public @interface Entity {
+    /**
+     * Optional explicit entity name. When absent the simple class name is used.
+     */
+    String value() default "";
 }

--- a/Java_intervew/src/Annotation/GeneratedValue.java
+++ b/Java_intervew/src/Annotation/GeneratedValue.java
@@ -6,10 +6,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Declares the table name that backs an entity.
+ * Describes how the identifier value of an entity should be generated.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
-public @interface Table {
-    String name() default "";
+@Target(ElementType.FIELD)
+public @interface GeneratedValue {
+    GenerationType strategy() default GenerationType.AUTO;
 }

--- a/Java_intervew/src/Annotation/GenerationType.java
+++ b/Java_intervew/src/Annotation/GenerationType.java
@@ -1,0 +1,11 @@
+package Annotation;
+
+/**
+ * Strategies for primary key generation in the simulated JPA layer.
+ */
+public enum GenerationType {
+    AUTO,
+    IDENTITY,
+    SEQUENCE,
+    TABLE
+}

--- a/Java_intervew/src/Annotation/Id.java
+++ b/Java_intervew/src/Annotation/Id.java
@@ -6,10 +6,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Declares the table name that backs an entity.
+ * Identifies the primary key field of an entity.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
-public @interface Table {
+@Target(ElementType.FIELD)
+public @interface Id {
+    /**
+     * Optional explicit column name for the identifier.
+     */
     String name() default "";
 }

--- a/Java_intervew/src/JpaRepo/JpaRepository.java
+++ b/Java_intervew/src/JpaRepo/JpaRepository.java
@@ -1,25 +1,201 @@
 package JpaRepo;
 
-public abstract class JpaRepository<E,T> implements CRUDRepository<E, T> {
+import Annotation.Column;
+import Annotation.Entity;
+import Annotation.Id;
+import Annotation.Table;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public abstract class JpaRepository<E, T> implements CRUDRepository<E, T> {
     @Override
     public void save(E entity) {
+        Objects.requireNonNull(entity, "Entity must not be null");
         Class<E> clazz = this.getEntityClass();
-        String tableName = clazz.getSimpleName();
+        validateEntityClass(clazz);
+
+        Map<String, Object> columnValues = extractColumnValues(entity, true);
+        String tableName = resolveTableName(clazz);
+
+        if (columnValues.isEmpty()) {
+            throw new IllegalStateException("No columns mapped for entity " + clazz.getName());
+        }
+
+        StringBuilder columnsBuilder = new StringBuilder();
+        StringBuilder placeholdersBuilder = new StringBuilder();
+        int index = 0;
+        for (String column : columnValues.keySet()) {
+            if (index > 0) {
+                columnsBuilder.append(", ");
+                placeholdersBuilder.append(", ");
+            }
+            columnsBuilder.append(column);
+            placeholdersBuilder.append("?");
+            index++;
+        }
+
+        String sql = String.format("INSERT INTO %s (%s) VALUES (%s);", tableName, columnsBuilder, placeholdersBuilder);
+        System.out.println(sql);
+        System.out.println("Parameters: " + new ArrayList<>(columnValues.values()));
     }
 
     @Override
     public void findById(T id) {
+        Objects.requireNonNull(id, "Identifier must not be null");
+        Class<E> clazz = this.getEntityClass();
+        validateEntityClass(clazz);
 
+        Field idField = resolveIdField(clazz);
+        String idColumn = resolveColumnName(idField);
+        String tableName = resolveTableName(clazz);
+
+        String sql = String.format("SELECT * FROM %s WHERE %s = ?;", tableName, idColumn);
+        System.out.println(sql);
+        System.out.println("Parameters: [" + id + "]");
     }
 
     @Override
     public void update(E entity) {
+        Objects.requireNonNull(entity, "Entity must not be null");
+        Class<E> clazz = this.getEntityClass();
+        validateEntityClass(clazz);
 
+        Field idField = resolveIdField(clazz);
+        Object idValue = Objects.requireNonNull(extractFieldValue(entity, idField),
+                "Identifier value must not be null");
+        String idColumn = resolveColumnName(idField);
+        Map<String, Object> columnValues = extractColumnValues(entity, false);
+        String tableName = resolveTableName(clazz);
+
+        List<String> assignments = new ArrayList<>();
+        for (String column : columnValues.keySet()) {
+            if (!column.equals(idColumn)) {
+                assignments.add(column + " = ?");
+            }
+        }
+
+        if (assignments.isEmpty()) {
+            throw new IllegalStateException("No updatable columns mapped for entity " + clazz.getName());
+        }
+
+        String sql = String.format("UPDATE %s SET %s WHERE %s = ?;", tableName, String.join(", ", assignments), idColumn);
+        List<Object> parameters = new ArrayList<>(columnValues.values());
+        parameters.add(idValue);
+        System.out.println(sql);
+        System.out.println("Parameters: " + parameters);
     }
 
     @Override
     public void deleteById(T id) {
+        Objects.requireNonNull(id, "Identifier must not be null");
+        Class<E> clazz = this.getEntityClass();
+        validateEntityClass(clazz);
 
+        Field idField = resolveIdField(clazz);
+        String idColumn = resolveColumnName(idField);
+        String tableName = resolveTableName(clazz);
+
+        String sql = String.format("DELETE FROM %s WHERE %s = ?;", tableName, idColumn);
+        System.out.println(sql);
+        System.out.println("Parameters: [" + id + "]");
     }
+
     public abstract Class<E> getEntityClass();
+
+    private Map<String, Object> extractColumnValues(E entity, boolean includeIdentifier) {
+        Map<String, Object> values = new LinkedHashMap<>();
+        Class<?> clazz = entity.getClass();
+        Field idField = resolveIdField(clazz);
+        Class<?> current = clazz;
+        while (current != null && current != Object.class) {
+            for (Field field : current.getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+                if (!field.isAnnotationPresent(Column.class) && !field.isAnnotationPresent(Id.class)) {
+                    continue;
+                }
+                boolean isId = field.equals(idField);
+                if (!includeIdentifier && isId) {
+                    continue;
+                }
+                String columnName = resolveColumnName(field);
+                Object value = extractFieldValue(entity, field);
+                values.put(columnName, value);
+            }
+            current = current.getSuperclass();
+        }
+        return values;
+    }
+
+    private Object extractFieldValue(E entity, Field field) {
+        try {
+            boolean accessible = field.canAccess(entity);
+            if (!accessible) {
+                field.setAccessible(true);
+            }
+            Object value = field.get(entity);
+            if (!accessible) {
+                field.setAccessible(false);
+            }
+            return value;
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("Cannot access field '" + field.getName() + "'", e);
+        }
+    }
+
+    private void validateEntityClass(Class<?> clazz) {
+        if (clazz == null) {
+            throw new IllegalStateException("Entity class must not be null");
+        }
+        if (!clazz.isAnnotationPresent(Entity.class)) {
+            throw new IllegalStateException("Class " + clazz.getName() + " is not annotated with @Entity");
+        }
+    }
+
+    private Field resolveIdField(Class<?> clazz) {
+        Field idField = null;
+        Class<?> current = clazz;
+        while (current != null && current != Object.class) {
+            for (Field field : current.getDeclaredFields()) {
+                if (field.isAnnotationPresent(Id.class)) {
+                    if (idField != null) {
+                        throw new IllegalStateException("Multiple @Id fields found in " + clazz.getName());
+                    }
+                    idField = field;
+                }
+            }
+            current = current.getSuperclass();
+        }
+        if (idField == null) {
+            throw new IllegalStateException("No field annotated with @Id found in " + clazz.getName());
+        }
+        return idField;
+    }
+
+    private String resolveTableName(Class<?> clazz) {
+        Table table = clazz.getAnnotation(Table.class);
+        if (table != null && !table.name().isEmpty()) {
+            return table.name();
+        }
+        return clazz.getSimpleName();
+    }
+
+    private String resolveColumnName(Field field) {
+        Id id = field.getAnnotation(Id.class);
+        if (id != null && !id.name().isEmpty()) {
+            return id.name();
+        }
+        Column column = field.getAnnotation(Column.class);
+        if (column != null && !column.name().isEmpty()) {
+            return column.name();
+        }
+        return field.getName();
+    }
 }


### PR DESCRIPTION
## Summary
- add runtime annotations for entity, identifier, and column metadata to describe mappings
- extend the generic JpaRepository to resolve table and column names via reflection and build SQL-like statements for CRUD operations
- include safety checks for entity metadata and identifier handling when simulating JPA interactions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8ca8c600c8323a7ca0be7f635bac8